### PR TITLE
Fixing rkt not being able to pull docker images

### DIFF
--- a/modules/ignition/assets.tf
+++ b/modules/ignition/assets.tf
@@ -149,8 +149,7 @@ data "template_file" "installer_kubelet_env" {
   template = "${file("${path.module}/resources/kubernetes/kubelet.env")}"
 
   vars {
-    kubelet_image_url = "${replace(var.container_images["hyperkube"],var.image_re,"$1")}"
-    kubelet_image_tag = "${replace(var.container_images["hyperkube"],var.image_re,"$2")}"
+    kubelet_image = "${var.container_images["hyperkube"]}"
   }
 }
 

--- a/modules/ignition/resources/kubernetes/kubelet.env
+++ b/modules/ignition/resources/kubernetes/kubelet.env
@@ -1,2 +1,1 @@
-KUBELET_IMAGE_URL="${kubelet_image_url}"
-KUBELET_IMAGE_TAG="${kubelet_image_tag}"
+KUBELET_IMAGE="docker://${kubelet_docker_image_override}"

--- a/modules/ignition/resources/kubernetes/kubelet.env
+++ b/modules/ignition/resources/kubernetes/kubelet.env
@@ -1,1 +1,1 @@
-KUBELET_IMAGE="docker://${kubelet_docker_image_override}"
+KUBELET_IMAGE="docker://${kubelet_image}"

--- a/modules/ignition/resources/services/kubelet.service
+++ b/modules/ignition/resources/services/kubelet.service
@@ -9,7 +9,8 @@ Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
   --volume var-lib-cni,kind=host,source=/var/lib/cni \
   --mount volume=var-lib-cni,target=/var/lib/cni \
   --volume var-log,kind=host,source=/var/log \
-  --mount volume=var-log,target=/var/log"
+  --mount volume=var-log,target=/var/log \
+  --insecure-options=image"
 
 ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
 ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests


### PR DESCRIPTION
Why?
-------------
Fixing a bug that does not allow rkt to pull newer hyperkube images and resulting in a vague error message

`run: discovery failed [kubelet-wrapper]`

More details is in this issue https://github.com/rkt/rkt/issues/3466

This happens because we moved from rkt/docker based quay.io/coreos/hyperkube -> gcr docker based hyperkube

Hyperkube moved repo
-----------------------------

The newer versions of hyperkube is no longer pushed to the quay repository only in gcr repo now 
http://gcr.io/google_containers/hyperkube
detailed here https://github.com/kubernetes-incubator/bootkube/issues/744

Running a docker image using rkt
----------------------------------------------------
https://coreos.com/rkt/docs/latest/running-docker-images.html


KUBELET_IMAGE env var 
--------------------------
KUBELET_IMAGE adds an override to the default kubelet-wrapper script found in
coreos distro

Kubelet-wrapper Source
-------------------------------

https://github.com/coreos/coreos-overlay/blob/master/app-admin/kubelet-wrapper/files/kubelet-wrapper

More documentation found here
https://github.com/coreos/coreos-kubernetes/blob/master/Documentation/kubelet-wrapper.md