### PR TITLE
Termination Policy: OldestInstance First for ASG

### DIFF
--- a/modules/aws/master-asg/master.tf
+++ b/modules/aws/master-asg/master.tf
@@ -32,8 +32,8 @@ resource "aws_autoscaling_group" "masters" {
   min_size             = "${var.instance_count}"
   launch_configuration = "${aws_launch_configuration.master_conf.id}"
   vpc_zone_identifier  = ["${var.subnet_ids}"]
-
-  load_balancers = ["${var.aws_lbs}"]
+  termination_policies = "OldestInstance"
+  load_balancers       = ["${var.aws_lbs}"]
 
   tags = [
     {

--- a/modules/aws/worker-asg/worker.tf
+++ b/modules/aws/worker-asg/worker.tf
@@ -57,6 +57,7 @@ resource "aws_autoscaling_group" "workers" {
   min_size             = "${var.instance_count}"
   launch_configuration = "${aws_launch_configuration.worker_conf.id}"
   vpc_zone_identifier  = ["${var.subnet_ids}"]
+  termination_policies = "OldestInstance"
 
   tags = [
     {


### PR DESCRIPTION
This is to prevent the asg killing the newly upgraded nodes