### PR TITLE
Allow cluster-autoscaler to set desired cap

### DIFF
--- a/modules/aws/master-asg/master.tf
+++ b/modules/aws/master-asg/master.tf
@@ -153,7 +153,10 @@ resource "aws_iam_role_policy" "master_policy" {
     {
       "Action" : [
         "autoscaling:DescribeAutoScalingGroups",
-        "autoscaling:DescribeAutoScalingInstances"
+        "autoscaling:DescribeAutoScalingInstances",
+        "autoscaling:DescribeTags",
+        "autoscaling:SetDesiredCapacity",
+        "autoscaling:TerminateInstanceInAutoScalingGroup"
       ],
       "Resource": "*",
       "Effect": "Allow"


### PR DESCRIPTION
Also allows the use of `--node-group-auto-discover` flag by adding` DescribeTags`
Terminate instance will also allow us to scale down aggressively if need be