### PR TITLE
kubelete image tag env vars

### DIFF
--- a/modules/ignition/assets.tf
+++ b/modules/ignition/assets.tf
@@ -150,6 +150,7 @@ data "template_file" "installer_kubelet_env" {
 
   vars {
     kubelet_image = "${var.container_images["hyperkube"]}"
+    kubelet_image_tag = "${replace(var.container_images["hyperkube"],var.image_re,"$2")}"
   }
 }
 

--- a/modules/ignition/resources/kubernetes/kubelet.env
+++ b/modules/ignition/resources/kubernetes/kubelet.env
@@ -1,1 +1,2 @@
 KUBELET_IMAGE="docker://${kubelet_image}"
+KUBELET_IMAGE_TAG="${kubelet_image_tag}


### PR DESCRIPTION
The cluster hasn't started properly and one of the errors in kubelet is that the image tag env var was missing, we noticed the codebase wasn't updated like 1.12.4.