### PR TITLE
Added datadog agent to etcd nodes

### DIFF
--- a/modules/aws/etcd/ignition.tf
+++ b/modules/aws/etcd/ignition.tf
@@ -4,6 +4,7 @@ data "ignition_config" "etcd" {
   systemd = [
     "${data.ignition_systemd_unit.locksmithd.*.id[count.index]}",
     "${var.ign_etcd_dropin_id_list[count.index]}",
+    "${var.ign_etcd_datadog_id}",
   ]
 
   files = ["${compact(list(

--- a/modules/aws/etcd/variables.tf
+++ b/modules/aws/etcd/variables.tf
@@ -109,3 +109,7 @@ variable "ign_systemd_default_env_id" {
 variable "ign_ntp_dropin_id" {
   type = "string"
 }
+
+variable "ign_etcd_datadog_id" {
+  type = "string"
+}

--- a/modules/ignition/etcd.tf
+++ b/modules/ignition/etcd.tf
@@ -79,7 +79,7 @@ data "ignition_systemd_unit" "etcd" {
 }
 
 data "ignition_systemd_unit" "etcd_datadog_agent" {
-  name = "dd-agent.service"
+  name    = "dd-agent.service"
   enabled = true
   content = "${data.template_file.etcd_datadog_agent.rendered}"
 }

--- a/modules/ignition/etcd.tf
+++ b/modules/ignition/etcd.tf
@@ -57,6 +57,14 @@ data "template_file" "etcd" {
   }
 }
 
+data "template_file" "etcd_datadog_agent" {
+  template = "${file("${path.module}/resources/services/dd-agent.service")}"
+
+  vars = {
+    datadog_api_key = "${var.datadog_api_key}"
+  }
+}
+
 data "ignition_systemd_unit" "etcd" {
   count   = "${var.etcd_count}"
   name    = "etcd-member.service"
@@ -68,6 +76,12 @@ data "ignition_systemd_unit" "etcd" {
       content = "${data.template_file.etcd.*.rendered[count.index]}"
     },
   ]
+}
+
+data "ignition_systemd_unit" "etcd_datadog_agent" {
+  name = "dd-agent.service"
+  enabled = true
+  content = "${data.template_file.etcd_datadog_agent.rendered}"
 }
 
 data "ignition_file" "etcd_ca" {

--- a/modules/ignition/outputs.tf
+++ b/modules/ignition/outputs.tf
@@ -179,3 +179,7 @@ output "nfs_config_id" {
 output "nfs_config_rendered" {
   value = "${file(var.nfs_config_file)}"
 }
+
+output "etcd_datadog_service_id" {
+  value = "${data.ignition_systemd_unit.etcd_datadog_agent.id}"
+}

--- a/modules/ignition/resources/services/dd-agent.service
+++ b/modules/ignition/resources/services/dd-agent.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Datadog Agent
+
+[Service]
+KillMode=none
+TimeoutStartSec=0
+TimeoutStopSec=360
+EnvironmentFile=/etc/environment
+Environment=INSTANCE=%i
+ExecStartPre=/usr/bin/bash -c "/usr/bin/docker stop dd-agent || true"
+ExecStartPre=/usr/bin/bash -c "/usr/bin/docker rm dd-agent || true"
+ExecStart=/usr/bin/docker run --name dd-agent \
+            -v /var/run/docker.sock:/var/run/docker.sock:ro \
+            -v /proc/:/host/proc/:ro \
+            -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
+            -v /opt/dd-agent-conf.d:/conf.d:ro \
+            -v /data/db:/data/db:ro \
+            -e API_KEY=${datadog_api_key} \
+            -e SD_BACKEND=docker \
+            -e NON_LOCAL_TRAFFIC=false \
+            datadog/docker-dd-agent:latest
+ExecStop=/usr/bin/docker stop dd-agent
+Restart=on-failure
+RestartSec=15

--- a/modules/ignition/resources/services/dd-agent.service
+++ b/modules/ignition/resources/services/dd-agent.service
@@ -14,7 +14,7 @@ ExecStart=/usr/bin/docker run --name dd-agent \
             -v /proc/:/host/proc/:ro \
             -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
             -e DD_API_KEY=${datadog_api_key} \
-            datadog/agent:latest
+            datadog/agent:6.10.2
 ExecStop=/usr/bin/docker stop dd-agent
 Restart=on-failure
 RestartSec=15

--- a/modules/ignition/resources/services/dd-agent.service
+++ b/modules/ignition/resources/services/dd-agent.service
@@ -13,12 +13,8 @@ ExecStart=/usr/bin/docker run --name dd-agent \
             -v /var/run/docker.sock:/var/run/docker.sock:ro \
             -v /proc/:/host/proc/:ro \
             -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-            -v /opt/dd-agent-conf.d:/conf.d:ro \
-            -v /data/db:/data/db:ro \
-            -e API_KEY=${datadog_api_key} \
-            -e SD_BACKEND=docker \
-            -e NON_LOCAL_TRAFFIC=false \
-            datadog/docker-dd-agent:latest
+            -e DD_API_KEY=${datadog_api_key} \
+            datadog/agent:latest
 ExecStop=/usr/bin/docker stop dd-agent
 Restart=on-failure
 RestartSec=15

--- a/modules/ignition/variables.tf
+++ b/modules/ignition/variables.tf
@@ -196,3 +196,8 @@ variable "nfs_config_file" {
 variable "proxy_exclusive_units" {
   type = "string"
 }
+
+variable "datadog_api_key" {
+  type = "string"
+  description = "API key for pushing metrics to DataDog via the agent"
+}

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -81,6 +81,7 @@ module "etcd" {
   ign_ntp_dropin_id          = "${length(var.tectonic_ntp_servers) > 0 ? module.ignition_masters.ntp_dropin_id : ""}"
   ign_profile_env_id         = "${module.ignition_masters.profile_env_id}"
   ign_systemd_default_env_id = "${module.ignition_masters.systemd_default_env_id}"
+  ign_etcd_datadog_id        = "${module.ignition_masters.etcd_datadog_service_id}"
   instance_count             = "${length(data.template_file.etcd_hostname_list.*.id)}"
   root_volume_iops           = "${var.tectonic_aws_etcd_root_volume_iops}"
   root_volume_size           = "${var.tectonic_aws_etcd_root_volume_size}"

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -132,6 +132,7 @@ module "ignition_masters" {
   ntp_servers               = "${var.tectonic_ntp_servers}"
   proxy_exclusive_units     = "${var.tectonic_proxy_exclusive_units}"
   tectonic_vanilla_k8s      = "${var.tectonic_vanilla_k8s}"
+  datadog_api_key           = "${var.datadog_api_key}"
 }
 
 module "masters" {

--- a/platforms/aws/variables.tf
+++ b/platforms/aws/variables.tf
@@ -345,3 +345,8 @@ Example:
  * `["ingress-nginx"]`
 EOF
 }
+
+variable "datadog_api_key" {
+  type        = "string"
+  description = "DataDog API key used by the DataDog agent"
+}


### PR DESCRIPTION
## Description

In order to add the DataDog agent to the etcd nodes, and gather performance metrics for those nodes (not just etcd itself, which we already have configured) we need to add the DataDog agent as a service via the ignition config within tectonic.

There are a lot of bits that connect together for this to work:

ignition -> platform/aws -> root config. Happy to explain further if required.