### PR TITLE
Default DataDog api key variable to empty string.

### DIFF
--- a/modules/ignition/variables.tf
+++ b/modules/ignition/variables.tf
@@ -198,6 +198,7 @@ variable "proxy_exclusive_units" {
 }
 
 variable "datadog_api_key" {
-  type = "string"
+  type        = "string"
   description = "API key for pushing metrics to DataDog via the agent"
+  default     = ""
 }


### PR DESCRIPTION
Default DataDog api key variable to empty string