### PR TITLE
adding install section

### DIFF
--- a/modules/ignition/resources/services/dd-agent.service
+++ b/modules/ignition/resources/services/dd-agent.service
@@ -18,3 +18,6 @@ ExecStart=/usr/bin/docker run --name dd-agent \
 ExecStop=/usr/bin/docker stop dd-agent
 Restart=on-failure
 RestartSec=15
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
As per the terraform docs, there needs to be an install section in order to use the enabled option
https://www.terraform.io/docs/providers/ignition/d/systemd_unit.html#enabled