### PR TITLE
[ZEN-713] [WIP] - Kubernetes upgrade to 1.13

### DIFF
--- a/modules/bootkube/resources/manifests/kube-apiserver.yaml
+++ b/modules/bootkube/resources/manifests/kube-apiserver.yaml
@@ -40,7 +40,6 @@ spec:
         ${etcd_ca_flag}
         ${etcd_cert_flag}
         ${etcd_key_flag}
-        - --etcd-quorum-read=true
         - --storage-backend=etcd3
         - --allow-privileged=true
         - --service-cluster-ip-range=${service_cidr}


### PR DESCRIPTION
**Ticket**
[ZEN-713](https://jira.condenastint.com/browse/ZEN-713)

**Description:**
Kubernetes 1.13.0 was released 5 months ago and brings with it a number of improvements (some new features, some stability). 1.14.0 has now also been released, we should look to upgrade to 1.13.x to avoid drifting too far from the current K8s version.

This PR will address any required changes for the upgrade process. 

**Changes:**
- Remove flag `etcd-quorum-read` from kube-apiserver because it's deprecated ([More info](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.13.md#action-required-1))

