### PR TITLE
 ZEN-28 Removed deprecated flag from the apiserv.yaml. 

### DIFF
--- a/modules/bootkube/resources/bootstrap-manifests/bootstrap-apiserver.yaml
+++ b/modules/bootkube/resources/bootstrap-manifests/bootstrap-apiserver.yaml
@@ -20,7 +20,6 @@ spec:
     - --cloud-provider=${cloud_provider}
     ${cloud_provider_config_flag}
     - --etcd-servers=${etcd_servers}
-    - --etcd-quorum-read=true
     ${etcd_ca_flag}
     ${etcd_cert_flag}
     ${etcd_key_flag}


### PR DESCRIPTION
## Description

Removed deprecated flag from api server manifest yaml.

The inclusion of this flag in the api server manifest means that during cluster creation some cluster resources  will not be created because they are dependant on communicating  with the api server.