### PR TITLE
Migrate Kubernetes master to private subnets 

### DIFF
--- a/modules/aws/master-asg/master.tf
+++ b/modules/aws/master-asg/master.tf
@@ -69,7 +69,7 @@ resource "aws_launch_configuration" "master_conf" {
   key_name                    = "${var.ssh_key}"
   security_groups             = ["${var.master_sg_ids}"]
   iam_instance_profile        = "${aws_iam_instance_profile.master_profile.arn}"
-  associate_public_ip_address = "${var.public_endpoints}"
+  associate_public_ip_address = false #"${var.public_endpoints}"
   user_data                   = "${data.ignition_config.s3.rendered}"
 
   lifecycle {

--- a/modules/aws/master-asg/master.tf
+++ b/modules/aws/master-asg/master.tf
@@ -34,7 +34,7 @@ resource "aws_autoscaling_group" "masters" {
   vpc_zone_identifier  = ["${var.subnet_ids}"]
   metrics_granularity  = "1Minute"
   enabled_metrics      = ["GroupMinSize", "GroupMaxSize", "GroupDesiredCapacity", "GroupInServiceInstances", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
-  termination_policies = "OldestInstance"
+  termination_policies = ["OldestInstance"]
 
   load_balancers = ["${var.aws_lbs}"]
 

--- a/modules/aws/master-asg/master.tf
+++ b/modules/aws/master-asg/master.tf
@@ -68,7 +68,7 @@ resource "aws_launch_configuration" "master_conf" {
   key_name                    = "${var.ssh_key}"
   security_groups             = ["${var.master_sg_ids}"]
   iam_instance_profile        = "${aws_iam_instance_profile.master_profile.arn}"
-  associate_public_ip_address = "${var.public_endpoints}"
+  associate_public_ip_address = false #"${var.public_endpoints}"
   user_data                   = "${data.ignition_config.s3.rendered}"
 
   lifecycle {

--- a/modules/aws/master-asg/master.tf
+++ b/modules/aws/master-asg/master.tf
@@ -69,7 +69,7 @@ resource "aws_launch_configuration" "master_conf" {
   key_name                    = "${var.ssh_key}"
   security_groups             = ["${var.master_sg_ids}"]
   iam_instance_profile        = "${aws_iam_instance_profile.master_profile.arn}"
-  associate_public_ip_address = false #"${var.public_endpoints}"
+  associate_public_ip_address = false 
   user_data                   = "${data.ignition_config.s3.rendered}"
 
   lifecycle {

--- a/modules/aws/master-asg/master.tf
+++ b/modules/aws/master-asg/master.tf
@@ -34,6 +34,7 @@ resource "aws_autoscaling_group" "masters" {
   vpc_zone_identifier  = ["${var.subnet_ids}"]
   metrics_granularity  = "1Minute"
   enabled_metrics      = ["GroupMinSize", "GroupMaxSize", "GroupDesiredCapacity", "GroupInServiceInstances", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
+  termination_policies = "OldestInstance"
 
   load_balancers = ["${var.aws_lbs}"]
 

--- a/modules/aws/master-asg/master.tf
+++ b/modules/aws/master-asg/master.tf
@@ -69,7 +69,7 @@ resource "aws_launch_configuration" "master_conf" {
   key_name                    = "${var.ssh_key}"
   security_groups             = ["${var.master_sg_ids}"]
   iam_instance_profile        = "${aws_iam_instance_profile.master_profile.arn}"
-  associate_public_ip_address = false 
+  associate_public_ip_address = false
   user_data                   = "${data.ignition_config.s3.rendered}"
 
   lifecycle {

--- a/modules/aws/master-asg/master.tf
+++ b/modules/aws/master-asg/master.tf
@@ -68,7 +68,7 @@ resource "aws_launch_configuration" "master_conf" {
   key_name                    = "${var.ssh_key}"
   security_groups             = ["${var.master_sg_ids}"]
   iam_instance_profile        = "${aws_iam_instance_profile.master_profile.arn}"
-  associate_public_ip_address = false #"${var.public_endpoints}"
+  associate_public_ip_address = "${var.public_endpoints}"
   user_data                   = "${data.ignition_config.s3.rendered}"
 
   lifecycle {

--- a/modules/aws/worker-asg/worker.tf
+++ b/modules/aws/worker-asg/worker.tf
@@ -59,7 +59,7 @@ resource "aws_autoscaling_group" "workers" {
   vpc_zone_identifier  = ["${var.subnet_ids}"]
   metrics_granularity  = "1Minute"
   enabled_metrics      = ["GroupMinSize", "GroupMaxSize", "GroupDesiredCapacity", "GroupInServiceInstances", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
-  termination_policies = "OldestInstance"
+  termination_policies = ["OldestInstance"]
 
   tags = [
     {

--- a/modules/aws/worker-asg/worker.tf
+++ b/modules/aws/worker-asg/worker.tf
@@ -51,16 +51,15 @@ resource "aws_launch_configuration" "worker_conf" {
 }
 
 resource "aws_autoscaling_group" "workers" {
-  name             = "${var.cluster_name}-workers"
-  desired_capacity = "${var.instance_count}"
-  max_size         = "${var.instance_count_max}"
-  min_size         = "${var.instance_count_min}"
-
+  name                 = "${var.cluster_name}-workers"
+  desired_capacity     = "${var.instance_count}"
+  max_size             = "${var.instance_count_max}"
+  min_size             = "${var.instance_count_min}"
   launch_configuration = "${aws_launch_configuration.worker_conf.id}"
-
-  vpc_zone_identifier = ["${var.subnet_ids}"]
-  metrics_granularity = "1Minute"
-  enabled_metrics     = ["GroupMinSize", "GroupMaxSize", "GroupDesiredCapacity", "GroupInServiceInstances", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
+  vpc_zone_identifier  = ["${var.subnet_ids}"]
+  metrics_granularity  = "1Minute"
+  enabled_metrics      = ["GroupMinSize", "GroupMaxSize", "GroupDesiredCapacity", "GroupInServiceInstances", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
+  termination_policies = "OldestInstance"
 
   tags = [
     {

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -184,7 +184,7 @@ module "masters" {
   root_volume_type                     = "${var.tectonic_aws_master_root_volume_type}"
   s3_bucket                            = "${aws_s3_bucket.tectonic.bucket}"
   ssh_key                              = "${var.tectonic_aws_ssh_key}"
-  subnet_ids                           = "${concat(module.vpc.master_subnet_ids, module.vpc.worker_subnet_ids)}"
+  subnet_ids                           = "${module.vpc.worker_subnet_ids}"
 }
 
 module "ignition_workers" {

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -184,7 +184,7 @@ module "masters" {
   root_volume_type                     = "${var.tectonic_aws_master_root_volume_type}"
   s3_bucket                            = "${aws_s3_bucket.tectonic.bucket}"
   ssh_key                              = "${var.tectonic_aws_ssh_key}"
-  subnet_ids                           = "${module.vpc.master_subnet_ids}"
+  subnet_ids                           = "${concat(module.vpc.master_subnet_ids, module.vpc.worker_subnet_ids)}"
 }
 
 module "ignition_workers" {


### PR DESCRIPTION
[Ticket ZEN-765](https://jira.condenastint.com/browse/ZEN-765)

Move master to private subnets:
- use private (aka worker) subnets
- apply ASG termination policy to delete the oldest instances
- remove public IPs for master instances

### Test
This was rolled-out to dev environment. 
- kube-api is responsive
- etcd-backups are capable of running 